### PR TITLE
Add preCreateWindow option

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,38 @@ module.exports = function create (opts) {
 
     menubar.emit('ready')
 
+    if (opts.preCreateWindow) {
+      createWindow(false)
+    }
+
+    function createWindow (show, x, y) {
+      menubar.emit('create-window')
+      var defaults = {
+        width: 400,
+        height: 400,
+        show: show,
+        frame: false
+      }
+
+      var winOpts = extend(defaults, {width: opts.width, height: opts.height})
+      menubar.window = new BrowserWindow(winOpts)
+
+      if (show) {
+        menubar.window.setPosition(x, y)
+      }
+
+      menubar.window.on('blur', hideWindow)
+      menubar.window.loadUrl(opts.index)
+      menubar.emit('after-create-window')
+    }
+
     function showWindow (bounds) {
       var x = opts.x || bounds.x - ((opts.width / 2) || 200) + (bounds.width / 2)
       var y = opts.y || bounds.y
+      if (!menubar.window) {
+        createWindow(true, x, y)
+      }
+
       if (menubar.window) {
         menubar.emit('show')
         menubar.window.show()
@@ -47,19 +76,6 @@ module.exports = function create (opts) {
         menubar.emit('after-show')
         return
       }
-      menubar.emit('create-window')
-      var defaults = {
-        width: 400,
-        height: 400,
-        show: true,
-        frame: false
-      }
-      var winOpts = extend(defaults, {width: opts.width, height: opts.height})
-      menubar.window = new BrowserWindow(winOpts)
-      menubar.window.setPosition(x, y)
-      menubar.window.on('blur', hideWindow)
-      menubar.window.loadUrl(opts.index)
-      menubar.emit('after-create-window')
     }
 
     function hideWindow () {

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ you can pass an optional options object into the menubar constructor
 - `index` (default `file:// + opts.dir + index.html`) - the html to load for the pop up window
 - `icon` (default opts.dir + 'Icon.png') - the png icon to use for the menubar
 - `tray` (default created on-the-fly) - an electron `Tray` instance. if provided `opts.icon` will be ignored
+- `preCreateWindow` (default false) - Create [BrowserWindow](https://github.com/atom/electron/blob/master/docs/api/browser-window.md) instance before it is used -- increasing resource usage, but making the click on the menubar load faster.
 - `width` (default 400) - window width
 - `height` (default 400) - window height
 - `x` (default screen.workArea.width - opts.width - 200) - the x position of the window


### PR DESCRIPTION
Which creates a `{show: false}` BrowserWindow on startup, decreasing load time on the first click of the Menubar itself.

Fairly noticeable on my macbook retina with any significant html/js being loaded.

I totally don't love the name `preCreateWindow`, ideas?
