### PR TITLE
Do not set blur event if "always-on-top" property is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = function create (opts) {
         bounds.x = size.width + size.x - (opts.width / 2) // default to right
         cachedBounds = bounds
       }
-      
+
       showWindow(cachedBounds)
     }
 
@@ -83,7 +83,8 @@ module.exports = function create (opts) {
         menubar.window.setPosition(x, y)
       }
 
-      menubar.window.on('blur', hideWindow)
+      if (!opts['always-on-top']) menubar.window.on('blur', hideWindow)
+
       menubar.window.loadUrl(opts.index)
       menubar.emit('after-create-window')
     }


### PR DESCRIPTION
#### What does this PR do?
* Allow `always-on-top` to be set.
* Could have added an option to overwrite the `blur` callback but that seemed like overkill

#### How should this be manually tested?
1. Set `always-on-top` to `true`
2. Open a menubar app
3. Ensure clicking on the icon continues to toggle the window state
4. Ensure clicking outside the app window keeps the window open

#### What are the relevant stories?
* https://github.com/maxogden/menubar/issues/26