### PR TITLE
Flexible "always-on-top" functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function create (opts) {
     }
 
     function clicked (e, bounds) {
-      if (menubar.window && menubar.window.isVisible()) return hideWindow()
+      if (menubar.window && menubar.window.isVisible()) return hideWindow(true)
 
       // workarea takes the taskbar/menubar height in consideration
       var size = electronScreen.getDisplayNearestPoint(electronScreen.getCursorScreenPoint()).workArea
@@ -83,7 +83,7 @@ module.exports = function create (opts) {
         menubar.window.setPosition(x, y)
       }
 
-      if (!opts['always-on-top']) menubar.window.on('blur', hideWindow)
+      menubar.window.on('blur', hideWindow)
 
       menubar.window.loadUrl(opts.index)
       menubar.emit('after-create-window')
@@ -105,8 +105,10 @@ module.exports = function create (opts) {
       }
     }
 
-    function hideWindow () {
-      if (!menubar.window) return
+    function hideWindow (forced) {
+      // `forced` can be an `Event` if called from blur, check against `true` to
+      // ensure proper functionality
+      if (!menubar.window || (menubar.window.isAlwaysOnTop() && forced !== true)) return
       menubar.emit('hide')
       menubar.window.hide()
       menubar.emit('after-hide')


### PR DESCRIPTION
#### What does this PR do?
* Allow changing "alwaysOnTop" property programmatically via `window.setAlwaysOnTop()`

#### Any background context you want to provide?
We need to trigger a dev mode (open devtools) while in a production state. This allows us to toggle "alwaysOnTop" based on the whether the devtools are opened or closed.