### PR TITLE
Always open menubar app on clicked screen

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,9 +83,9 @@ module.exports = function create (opts) {
       // double click sometimes returns `undefined`
       bounds = bounds || cachedBounds
 
-      // default to bottom on windows if `bounds.y` is not set
-      // leave it open to use prepopulated `bounds` if/when windows sets it
-      if (process.platform === 'win32' && bounds.y === 0) bounds.y = size.height - opts.height
+      // default to bottom on windows
+      // even when `bounds` is set, it doesn't take the app height in consideration
+      if (process.platform === 'win32') bounds.y = size.height - opts.height
 
       if (bounds.x === 0) {
         // default to right


### PR DESCRIPTION
#### What does this PR do?
* Open the menubar app on the screen that was clicked, not always the focused one.
* Separate the workaround so it can easily be removed if/when electron fixes in core.

#### How should this be manually tested?
Open the menubar example app on separate displays with various configuration (vertically stacked, horizontally stacked) and make sure it always aligns properly

#### What are the relevant issues?
* https://github.com/maxogden/menubar/issues/19
* https://github.com/maxogden/menubar/pull/20
* https://github.com/atom/electron/issues/1847
* https://github.com/maxogden/menubar/issues/32