### PR TITLE
window does not like non-integer pos, floor it

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ module.exports = function create (opts) {
     }
 
     function showWindow (trayPos) {
-      var x = opts.x || trayPos.x - ((opts.width / 2) || 200) + (trayPos.width / 2)
+      var x = opts.x || Math.floor(trayPos.x - ((opts.width / 2) || 200) + (trayPos.width / 2))
       var y = opts.y || trayPos.y
       if (!menubar.window) {
         createWindow(true, x, y)


### PR DESCRIPTION
To reproduce this issue (on OSX at least)

```js
var menubar = require('menubar')
var mb = menubar()

mb.on('ready', function ready () {
  console.log('app is ready')
  mb.tray.setTitle('1234567')
})
```
