### PR TITLE
Update default icon path to reflect readme

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function create (opts) {
   function appReady () {
     if (app.dock) app.dock.hide()
 
-    var iconPath = opts.icon || path.join(opts.dir, 'IconTemplate.png')
+    var iconPath = opts.icon || path.join(opts.dir, 'Icon.png')
     if (!fs.existsSync(iconPath)) iconPath = path.join(__dirname, 'example', 'IconTemplate.png') // default cat icon
 
     var electronScreen = require('screen')

--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ you can pass an optional options object into the menubar constructor
 
 - `dir` (default `process.cwd()`) - the app source directory
 - `index` (default `file:// + opts.dir + index.html`) - the html to load for the pop up window
-- `icon` (default opts.dir + 'Icon.png') - the png icon to use for the menubar
+- `icon` (default `opts.dir + Icon.png`) - the png icon to use for the menubar
 - `tray` (default created on-the-fly) - an electron `Tray` instance. if provided `opts.icon` will be ignored
 - `preloadWindow` (default false) - Create [BrowserWindow](https://github.com/atom/electron/blob/master/docs/api/browser-window.md) instance before it is used -- increasing resource usage, but making the click on the menubar load faster.
 - `width` (default 400) - window width


### PR DESCRIPTION
[The readme says it's defaulted to `Icon.png`](https://github.com/maxogden/menubar#options) but it's actually set to `IconTemplate.png`.

:cat2: