### PR TITLE
Set tooltip on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,10 @@ module.exports = function create (opts) {
       .on('clicked', clicked)
       .on('double-clicked', clicked)
 
+    if (process.platform === 'linux') {
+      menubar.tray.setToolTip('Show Menu Window')
+    }
+
     menubar.emit('ready')
 
     if (opts.preloadWindow) {


### PR DESCRIPTION
On Linux, clicking menu icon doesn't show up window immediately.  It shows an empty context menu and clicking the context menu finally shows a window.

![before](https://dl.dropboxusercontent.com/u/2753138/foo.jpg)

I think an empty menu is not good for UX.  So I set a message "Show Menu
Window" to tooltip of the tray.

![after](https://dl.dropboxusercontent.com/u/2753138/bar.jpg)

I don't know how to make clicking icon open popup window immediately on Linux yet.  I'll send another pull request if I find the way :smile:
- Environment
  - Ubuntu Linux 12.04
  - Electron 0.30.1
