### PR TITLE
Make window visible on all workspaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,8 @@ module.exports = function create (opts) {
 
       if (!opts['always-on-top']) menubar.window.on('blur', hideWindow)
 
+      menubar.window.setVisibleOnAllWorkspaces(true)
+
       menubar.window.loadUrl(opts.index)
       menubar.emit('after-create-window')
     }


### PR DESCRIPTION
On OS X, the menu window is bound to specific workspace where the app starts up.  When I clicked the icon of menu bar in other workspace, it moved the current workspace to the bound workspace.

1. Start menubar app on workspace A.
2. Hide the app.
3. Move to workspace B.
4. Click icon in menu bar in B.
5. Automatically move to workspace A and the menu window shows up.

I found that [BrowserWindow.setVisibleOnAllWorkspaces(visible)](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#browserwindowsetvisibleonallworkspacesvisible) can solve the problem and made this pull request.  It shows menu window always in current workspace.