### PR TITLE
Change default icon name

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function create (opts) {
   function appReady () {
     if (app.dock) app.dock.hide()
 
-    var iconPath = opts.icon || path.join(opts.dir, 'Icon.png')
+    var iconPath = opts.icon || path.join(opts.dir, 'IconTemplate.png')
     if (!fs.existsSync(iconPath)) iconPath = path.join(__dirname, 'example', 'IconTemplate.png') // default cat icon
 
     var electronScreen = require('screen')

--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ you can pass an optional options object into the menubar constructor
 
 - `dir` (default `process.cwd()`) - the app source directory
 - `index` (default `file:// + opts.dir + index.html`) - the html to load for the pop up window
-- `icon` (default `opts.dir + Icon.png`) - the png icon to use for the menubar
+- `icon` (default `opts.dir + IconTemplate.png`) - the png icon to use for the menubar
 - `tray` (default created on-the-fly) - an electron `Tray` instance. if provided `opts.icon` will be ignored
 - `preloadWindow` (default false) - Create [BrowserWindow](https://github.com/atom/electron/blob/master/docs/api/browser-window.md) instance before it is used -- increasing resource usage, but making the click on the menubar load faster.
 - `width` (default 400) - window width


### PR DESCRIPTION
Following up #34 in light of https://github.com/muan/mojibar/pull/8 and https://github.com/maxogden/menubar/pull/34#commitcomment-12483477.

Mac icon names need to be suffixed with 'Template' to be treated as a Template, which would then adapt to OSX UI scheme(dark/light), therefore it makes more sense to have the default icon name be 'IconTemplate' than 'Icon'. Sorry for the back and forth. :pray: 

See http://git.io/vOlVE.