### PR TITLE
Set and get options after menubar is created

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,15 @@ module.exports = function create (opts) {
   var menubar = new events.EventEmitter()
   menubar.app = app
 
+  // Set / get options
+  menubar.setOption = function (opt, val) {
+    opts[opt] = val
+  }
+
+  menubar.getOption = function (opt) {
+    return opts[opt]
+  }
+
   return menubar
 
   function appReady () {

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,9 @@ the return value of `mb` is an event emitter with these properties:
 {
   app: the electron require('app') instance,
   window: the electron require('browser-window') instance,
-  tray: the electron require('tray') instance
+  tray: the electron require('tray') instance,
+  setOption(option, value): change an option after menubar is created,
+  getOption(option): get an menubar option
 }
 ```
 


### PR DESCRIPTION
Good to have when you need to set some option after the app is created. For instance when you have some logic that depends on electrons `screen` module which can't run before the app is ready.