### PR TITLE
free key+click events for special cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,8 @@ module.exports = function create (opts) {
     }
 
     function clicked (e, bounds) {
+      if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) return hideWindow()
+
       if (menubar.window && menubar.window.isVisible()) return hideWindow()
 
       // workarea takes the taskbar/menubar height in consideration


### PR DESCRIPTION
The goal of this one line PR is to free key+click events (with Alt, Ctrl, Shift and "meta"), so that these can be used to show different menubars than the main one.