### PR TITLE
Make show/hide-window available outside

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,11 +50,14 @@ module.exports = function create (opts) {
       .on('clicked', clicked)
       .on('double-clicked', clicked)
 
-    menubar.emit('ready')
-
     if (opts.preloadWindow) {
       createWindow(false)
     }
+
+    menubar.showWindow = showWindow
+    menubar.hideWindow = hideWindow
+
+    menubar.emit('ready')
 
     /**
      * Temporary workaround to retrieve the coordinates of the clicked display.
@@ -132,8 +135,8 @@ module.exports = function create (opts) {
     }
 
     function showWindow (trayPos) {
-      var x = opts.x || Math.floor(trayPos.x - ((opts.width / 2) || 200) + (trayPos.width / 2))
-      var y = opts.y || trayPos.y
+      var x = (opts.x !== undefined) ? opts.x : Math.floor(trayPos.x - ((opts.width / 2) || 200) + (trayPos.width / 2))
+      var y = (opts.y !== undefined) ? opts.y : trayPos.y
       if (!menubar.window) {
         createWindow(true, x, y)
       }


### PR DESCRIPTION
Adds `showWindow()` and `hideWindow()` to the menubar object. This is better than just running `mb.window.show()` as these functions trigger events and contains some nice logic.

This also fixes two other issues:
1. If you preload the window, `menubar.window` is now available on the ready event.
2. `opts.x` and `opts.y` can now be set to `0`.

:swimmer: