### PR TITLE
add openDevTools option

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,10 @@ module.exports = function create (opts) {
         menubar.window.setVisibleOnAllWorkspaces(true)
       }
 
+      if (opts['openDevTools']) {
+        menubar.window.openDevTools()
+      }
+
       menubar.window.loadUrl(opts.index)
       menubar.emit('after-create-window')
     }

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ you can pass an optional options object into the menubar constructor
 - `show-on-all-workspaces` (default true) - Makes the window available on all OS X workspaces.
 - `window-position` (default trayCenter and trayBottomCenter on Windows) - Sets the window position (x and y will still override this), check [positioner docs](https://github.com/jenslind/electron-positioner#docs) for valid values.
 - `showDockIcon` (default false) - Configure the visibility of the application dock icon.
+- `openDevTools` (default false) - Open the devtools when create window.
 
 ## events
 


### PR DESCRIPTION
It should have an option to open devtool after creating `browserWindow`

![](http://ww3.sinaimg.cn/large/62580dd9gw1exqa0ktdd9j20bl0bzt94.jpg)