### PR TITLE
add devMode option for webpack users

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,13 @@ module.exports = function create (opts) {
         menubar.window.setVisibleOnAllWorkspaces(true)
       }
 
-      menubar.window.loadUrl(opts.index)
+      // for webpack dev server
+      if (opts['devMode']) {
+        menubar.window.loadUrl(typeof opts['devMode'] === 'string' ? opts['devMode'] : 'http://localhost:8080/')
+      } else {
+        menubar.window.loadUrl(opts.index)
+      }
+
       menubar.emit('after-create-window')
     }
 

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ you can pass an optional options object into the menubar constructor
 - `show-on-all-workspaces` (default true) - Makes the window available on all OS X workspaces.
 - `window-position` (default trayCenter and trayBottomCenter on Windows) - Sets the window position (x and y will still override this), check [positioner docs](https://github.com/jenslind/electron-positioner#docs) for valid values.
 - `showDockIcon` (default false) - Configure the visibility of the application dock icon.
+- `devMode` (default false) - Switch to dev mode for webpack user who want to load `dev server url` instead of the `file url`. Setting `true` for loading `http://localhost:8080/` by default, or setting a string url for loading specific url.
 
 ## events
 


### PR DESCRIPTION
Add `devMode` option for the webpack users. 

`devMode` (default false) - Switch to dev mode for webpack user who want to load `dev server url` instead of the `file url`. Setting `true` for loading `http://localhost:8080/` by default, or setting a string url for loading specific url.