### PR TITLE
Move bounds cache to showWindow method

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,10 +68,6 @@ module.exports = function create (opts) {
 
       if (menubar.window && menubar.window.isVisible()) return hideWindow()
 
-      // double click sometimes returns `undefined`
-      bounds = bounds || cachedBounds
-
-      cachedBounds = bounds
       showWindow(cachedBounds)
     }
 
@@ -105,6 +101,14 @@ module.exports = function create (opts) {
       }
 
       menubar.emit('show')
+      
+      if (trayPos && trayPos.x != 0) {
+        // Cache the bounds
+        cachedBounds = trayPos
+      } else if (cachedBounds) {
+        // Cached value will be used if showWindow is called without bounds data
+        trayPos = cachedBounds
+      }
 
       // Default the window to the right if `trayPos` bounds are undefined or null.
       var noBoundsPosition = null

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ module.exports = function create (opts) {
       }
 
       menubar.emit('show')
-      
+
       if (trayPos && trayPos.x !== 0) {
         // Cache the bounds
         cachedBounds = trayPos

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = function create (opts) {
 
       menubar.emit('show')
       
-      if (trayPos && trayPos.x != 0) {
+      if (trayPos && trayPos.x !== 0) {
         // Cache the bounds
         cachedBounds = trayPos
       } else if (cachedBounds) {


### PR DESCRIPTION
This allows showWindow to be called manually and the window will appear in the correct place assuming the tray has already been clicked at some stage.

My use case is that I want the tray to open on the `drop-files` event. Previous to this, calling `showWindow(null)` would position the window at the top-right (OS X). This is not an ideal solution because if the tray hasn't been clicked previously then the window will still appear in the top-right. A better solution could be implemented upstream in Electron (see: https://github.com/atom/electron/issues/3377).

This is a breaking change because it changes the behaviour of `menuBar.showWindow(null)` after the tray has been clicked.

This may not be a desirable PR for the reasons mentioned above but I'll submit it for reference anyway.