### PR TITLE
Update electron-positioner dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/maxogden/menubar",
   "dependencies": {
-    "electron-positioner": "^2.0.1",
+    "electron-positioner": "^2.0.3",
     "extend": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
So that we get this fix for the menubar: https://github.com/jenslind/electron-positioner/pull/2