### PR TITLE
Cleaning up window when closed by hotkey

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,8 @@ module.exports = function create (opts) {
         menubar.window.setVisibleOnAllWorkspaces(true)
       }
 
+      menubar.window.on('close', windowClear)
+
       menubar.window.loadURL(opts.index)
       menubar.emit('after-create-window')
     }
@@ -128,6 +130,11 @@ module.exports = function create (opts) {
       menubar.emit('hide')
       menubar.window.hide()
       menubar.emit('after-hide')
+    }
+
+    function windowClear () {
+      delete menubar.window
+      menubar.emit('after-close')
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ the return value of the menubar constructor is an event emitter
 - `after-show` - the line after window.show is called
 - `hide` - the line before window.hide is called (on window blur)
 - `after-hide` - the line after window.hide is called
+- `after-close` - after the .window (BrowserWindow) property has been deleted
 
 ## tips
 


### PR DESCRIPTION
I had an issue whereby if I closed the menubar instance via cmd+w the menubar would become unrecoverable as the .window property was closed but the createWindow() function is not exported to replace.

The new functionality deletes the window property when 'close' is fired, when the showWindow() function is fired afterwards it will rebuild the window.