### PR TITLE
Use camelCase for options

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = function create (opts) {
       menubar.positioner = new Positioner(menubar.window)
 
       menubar.window.on('blur', function () {
-        opts['always-on-top'] ? emitBlur() : hideWindow()
+        opts.alwaysOnTop ? emitBlur() : hideWindow()
       })
 
       if (opts.showOnAllWorkspaces !== false) {

--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ module.exports = function create (opts) {
   if (!opts.dir) opts.dir = app.getAppPath()
   if (!(path.isAbsolute(opts.dir))) opts.dir = path.resolve(opts.dir)
   if (!opts.index) opts.index = 'file://' + path.join(opts.dir, 'index.html')
-  if (!opts['window-position']) opts['window-position'] = (process.platform === 'win32') ? 'trayBottomCenter' : 'trayCenter'
-  if (typeof opts['show-dock-icon'] === 'undefined') opts['show-dock-icon'] = false
+  if (!opts.windowPosition) opts.windowPosition = (process.platform === 'win32') ? 'trayBottomCenter' : 'trayCenter'
+  if (typeof opts.showDockIcon === 'undefined') opts.showDockIcon = false
 
   // set width/height on opts to be usable before the window is created
   opts.width = opts.width || 400
@@ -41,20 +41,20 @@ module.exports = function create (opts) {
   return menubar
 
   function appReady () {
-    if (app.dock && !opts['show-dock-icon']) app.dock.hide()
+    if (app.dock && !opts.showDockIcon) app.dock.hide()
 
     var iconPath = opts.icon || path.join(opts.dir, 'IconTemplate.png')
     if (!fs.existsSync(iconPath)) iconPath = path.join(__dirname, 'example', 'IconTemplate.png') // default cat icon
 
     var cachedBounds // cachedBounds are needed for double-clicked event
-    var defaultClickEvent = opts['show-on-right-click'] ? 'right-click' : 'click'
+    var defaultClickEvent = opts.showOnRightClick ? 'right-click' : 'click'
 
     menubar.tray = opts.tray || new Tray(iconPath)
     menubar.tray.on(defaultClickEvent, clicked)
     menubar.tray.on('double-click', clicked)
     menubar.tray.setToolTip(opts.tooltip)
 
-    if (opts.preloadWindow || opts['preload-window']) {
+    if (opts.preloadWindow) {
       createWindow()
     }
 
@@ -81,13 +81,13 @@ module.exports = function create (opts) {
 
       menubar.positioner = new Positioner(menubar.window)
 
-      if (!opts['always-on-top']) {
+      if (!opts.alwaysOnTop) {
         menubar.window.on('blur', hideWindow)
       } else {
         menubar.window.on('blur', emitBlur)
       }
 
-      if (opts['show-on-all-workspaces'] !== false) {
+      if (opts.showOnAllWorkspaces !== false) {
         menubar.window.setVisibleOnAllWorkspaces(true)
       }
 
@@ -113,11 +113,11 @@ module.exports = function create (opts) {
 
       // Default the window to the right if `trayPos` bounds are undefined or null.
       var noBoundsPosition = null
-      if ((trayPos === undefined || trayPos.x === 0) && opts['window-position'].substr(0, 4) === 'tray') {
+      if ((trayPos === undefined || trayPos.x === 0) && opts.windowPosition.substr(0, 4) === 'tray') {
         noBoundsPosition = (process.platform === 'win32') ? 'bottomRight' : 'topRight'
       }
 
-      var position = menubar.positioner.calculate(noBoundsPosition || opts['window-position'], trayPos)
+      var position = menubar.positioner.calculate(noBoundsPosition || opts.windowPosition, trayPos)
 
       var x = (opts.x !== undefined) ? opts.x : position.x
       var y = (opts.y !== undefined) ? opts.y : position.y

--- a/readme.md
+++ b/readme.md
@@ -78,16 +78,16 @@ you can pass an optional options object into the menubar constructor
 - `icon` (default `opts.dir + IconTemplate.png`) - the png icon to use for the menubar. A good size to start with is 20x20. To support retina, supply a 2x sized image (e.g. 40x40) with `@2x` added to the end of the name, so `icon.png` and `icon@2x.png` and Electron will automatically use your `@2x` version on retina screens.
 - `tooltip` (default empty) - menubar tray icon tooltip text
 - `tray` (default created on-the-fly) - an electron `Tray` instance. if provided `opts.icon` will be ignored
-- `preload-window` (default false) - Create [BrowserWindow](https://github.com/atom/electron/blob/master/docs/api/browser-window.md) instance before it is used -- increasing resource usage, but making the click on the menubar load faster.
+- `preloadWindow` (default false) - Create [BrowserWindow](https://github.com/atom/electron/blob/master/docs/api/browser-window.md) instance before it is used -- increasing resource usage, but making the click on the menubar load faster.
 - `width` (default 400) - window width
 - `height` (default 400) - window height
 - `x` (default null) - the x position of the window
 - `y` (default null) - the y position of the window
-- `always-on-top` (default false) - if true, the window will not hide on blur
-- `show-on-all-workspaces` (default true) - Makes the window available on all OS X workspaces.
-- `window-position` (default trayCenter and trayBottomCenter on Windows) - Sets the window position (x and y will still override this), check [positioner docs](https://github.com/jenslind/electron-positioner#docs) for valid values.
-- `show-dock-icon` (default false) - Configure the visibility of the application dock icon.
-- `show-on-right-click` (default false) - Show the window on 'right-click' event instead of regular 'click'
+- `alwaysOnTop` (default false) - if true, the window will not hide on blur
+- `showOnAllWorkspaces` (default true) - Makes the window available on all OS X workspaces.
+- `windowPosition` (default trayCenter and trayBottomCenter on Windows) - Sets the window position (x and y will still override this), check [positioner docs](https://github.com/jenslind/electron-positioner#docs) for valid values.
+- `showDockIcon` (default false) - Configure the visibility of the application dock icon.
+- `showOnRightClick` (default false) - Show the window on 'right-click' event instead of regular 'click'
 
 ## events
 
@@ -107,4 +107,4 @@ the return value of the menubar constructor is an event emitter
 
 - Use `mb.on('after-create-window', callback)` to run things after your app has loaded. For example you could run `mb.window.openDevTools()` to open the developer tools for debugging, or load a different URL with `mb.window.loadUrl()`
 
-- Use `mb.on('focus-lost')` if you would like to perform some operation when using the option `always-on-top:true`
+- Use `mb.on('focus-lost')` if you would like to perform some operation when using the option `alwaysOnTop:true`


### PR DESCRIPTION
Since electron has moved to camelCase it makes sense to do the same for menubar.

See #113 

@maxogden would love some feedback on this since we need to do a major bump if we gonna go with camelCases. :)