### PR TITLE
Add support for 'drop-files' event

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function create (opts) {
     menubar.tray = opts.tray || new Tray(iconPath)
     menubar.tray.on(defaultClickEvent, clicked)
     menubar.tray.on('double-click', clicked)
-    menubar.tray.on('drop-files', dropped);
+    menubar.tray.on('drop-files', dropped)
     menubar.tray.setToolTip(opts.tooltip)
 
     if (opts.preloadWindow || opts['preload-window']) {

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ module.exports = function create (opts) {
     menubar.tray = opts.tray || new Tray(iconPath)
     menubar.tray.on(defaultClickEvent, clicked)
     menubar.tray.on('double-click', clicked)
+    menubar.tray.on('drop-files', dropped);
     menubar.tray.setToolTip(opts.tooltip)
 
     if (opts.preloadWindow || opts['preload-window']) {
@@ -61,6 +62,10 @@ module.exports = function create (opts) {
     menubar.showWindow = showWindow
     menubar.hideWindow = hideWindow
     menubar.emit('ready')
+
+    function dropped (e, files) {
+      menubar.emit('drop-files', files)
+    }
 
     function clicked (e, bounds) {
       if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) return hideWindow()

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,7 @@ the return value of the menubar constructor is an event emitter
 - `after-hide` - the line after window.hide is called
 - `after-close` - after the .window (BrowserWindow) property has been deleted
 - `focus-lost` - emitted if always-on-top option is set and the user clicks away
+- `drop-files` - emitted if user drags files on tray icon, contains array of paths to these files
 
 ## tips
 


### PR DESCRIPTION
Recently I tried adding custom Tray by providing it to constructor but it appeared that following code:

```
const tray = new Tray('./iconTemplate.png');
const mb = menubar({
  width: 400,
  height: 300,
  'show-dock-icon': false,
  tray
});
```

Is not possible due to this: https://github.com/electron/electron/pull/1297/files

I've also tried wrapping this code into `app.on('ready', () => { ... } ` but of course it didn't worked. 

My solution to that problem simply passes `drop-files` event from tray to `menubar` just like in `double-click` case. 

Another solution might be exposing `tray` property from menubar so all events could be handled by developer. (`mb.getOption('tray').on('drop-files', () => { ... ` or ` mb.tray.on('drop-files', ... ` don't work right now). 

Let me know what do you think.
