### PR TITLE
Example App: bumped to 0.36.4; updated npm run build script

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -7,11 +7,11 @@
   },
   "devDependencies": {
     "electron-packager": "^5.1.0",
-    "electron-prebuilt": "^0.36.0"
+    "electron-prebuilt": "^0.36.4"
   },
   "main": "main.js",
   "scripts": {
-    "build": "electron-packager . Example --platform=darwin --arch=x64 --version=0.36.0 --icon=Icon.icns",
+    "build": "electron-packager . Example --platform=darwin --arch=x64 --version=0.36.4 --icon=Icon.icns",
     "start": "electron ."
   }
 }


### PR DESCRIPTION
Sup Max!

I had to bump the `electron-prebuilt` to a later version to get the menubar example to run on Mac.

Slick project, btw.
