### PR TITLE
Added rightclick event to tray, that emits giving you ability to act upon it

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function create (opts) {
     menubar.tray = opts.tray || new Tray(iconPath)
     menubar.tray.on(defaultClickEvent, clicked)
     menubar.tray.on('double-click', clicked)
-    menubar.tray.on('right-click', rightclicked);
+    menubar.tray.on('right-click', rightclicked)
     menubar.tray.setToolTip(opts.tooltip)
 
     var supportsTrayHighlightState = false

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ module.exports = function create (opts) {
     menubar.tray = opts.tray || new Tray(iconPath)
     menubar.tray.on(defaultClickEvent, clicked)
     menubar.tray.on('double-click', clicked)
+    menubar.tray.on('right-click', rightclicked);
     menubar.tray.setToolTip(opts.tooltip)
 
     var supportsTrayHighlightState = false
@@ -73,6 +74,10 @@ module.exports = function create (opts) {
       if (menubar.window && menubar.window.isVisible()) return hideWindow()
       cachedBounds = bounds || cachedBounds
       showWindow(cachedBounds)
+    }
+
+    function rightclicked () {
+      menubar.emit('right-click')
     }
 
     function createWindow () {


### PR DESCRIPTION
I wanted to be able to have a context menu when right-clicking on the tray icon (nicest way to quit the app for example), but show the normal BrowserWindow when left-clicking. 

The change purely adds the right-click event to the tray, and emits that for use in your app. 

For example, for me showing the context menu I was then able to do the following in my app.

`mb.on('right-click', function(){
	mb.tray.popUpContextMenu(contextMenu)
});`