### PR TITLE
Ensure to launch application

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,11 @@ module.exports = function create (opts) {
   opts.height = opts.height || 400
   opts.tooltip = opts.tooltip || ''
 
-  app.on('ready', appReady)
+  if (app.isReady()) {
+    process.nextTick(appReady)
+  } else {
+    app.on('ready', appReady)
+  }
 
   var menubar = new events.EventEmitter()
   menubar.app = app


### PR DESCRIPTION
When menubar() is called after `app`'s `ready` event was emitted, application will never be launched. This is because application is launched on the `ready` event in menubar package.

I fixed this by checking `app` is already ready.  This change does not break current behavior :+1:

I confirmed the problem and this patch fixed it on OS X 10.11.6 and Electron 1.4.2.
