### PR TITLE
allow setOption with icon to change tray image

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,10 @@ module.exports = function create (opts) {
   // Set / get options
   menubar.setOption = function (opt, val) {
     opts[opt] = val
+    if (opt === 'icon') {
+      var iconPath = getIconPath(val)
+      menubar.tray.setImage(iconPath)
+    }
   }
 
   menubar.getOption = function (opt) {
@@ -40,14 +44,18 @@ module.exports = function create (opts) {
 
   return menubar
 
+  function getIconPath (icon) {
+    var iconPath = icon || path.join(opts.dir, 'IconTemplate.png')
+    if (!fs.existsSync(iconPath)) iconPath = path.join(__dirname, 'example', 'IconTemplate.png') // default cat icon
+    return iconPath
+  }
+
   function appReady () {
     if (app.dock && !opts.showDockIcon) app.dock.hide()
 
-    var iconPath = opts.icon || path.join(opts.dir, 'IconTemplate.png')
-    if (!fs.existsSync(iconPath)) iconPath = path.join(__dirname, 'example', 'IconTemplate.png') // default cat icon
-
     var cachedBounds // cachedBounds are needed for double-clicked event
     var defaultClickEvent = opts.showOnRightClick ? 'right-click' : 'click'
+    var iconPath = getIconPath(opts.icon)
 
     menubar.tray = opts.tray || new Tray(iconPath)
     menubar.tray.on(defaultClickEvent, clicked)


### PR DESCRIPTION
This will allow you to use `setOption` to change the icon in the `Tray`. The reason for this is just in case there are some states in your application that you would like to make very apparent. An example could be a screen recording app. You might want to have the initial button be a play button and then when its actively recording the tray icon changes to a stop or pause button. Another example is if the application has a long running task, you can then indicate that the task is active, and inactive by changing the icon.

This is possibly a fix for #134 even tho it sound like they are asking for an animated image.
