### PR TITLE
Fix window does not show when already app is ready (broken in #145)

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function create (opts) {
   opts.height = opts.height || 400
   opts.tooltip = opts.tooltip || ''
 
-  if (app.isReady()) appReady()
+  if (app.isReady()) process.nextTick(appReady)
   else app.on('ready', appReady)
 
   var menubar = new events.EventEmitter()


### PR DESCRIPTION
`appReady()` is not considered to be called in `create()`. So calling
it directly in `create()` does not work (I confirmed it at least in my app). #145 does not work.
My PR (#144) was care about it but it was closed.