### PR TITLE
Use app.hide() on macOS (fix #153)

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,11 @@ module.exports = function create (opts) {
       if (supportsTrayHighlightState) menubar.tray.setHighlightMode('never')
       if (!menubar.window) return
       menubar.emit('hide')
-      menubar.window.hide()
+      if (process.platform === 'darwin') {
+        menubar.app.hide()
+      } else {
+        menubar.window.hide()
+      }
       menubar.emit('after-hide')
     }
 


### PR DESCRIPTION
I found that using `app.hide()` instead of `BrowserWindow.hide()` solves focus problem on hiding menubar application.

https://github.com/electron/electron/blob/master/docs/api/browser-window.md

This should fix #153