### PR TITLE
Fix app undefined when menubar created within app.ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,11 @@ module.exports = function create (opts) {
   opts.height = opts.height || 400
   opts.tooltip = opts.tooltip || ''
 
-  if (app.isReady()) appReady()
-  else app.on('ready', appReady)
-
   var menubar = new events.EventEmitter()
   menubar.app = app
+
+  if (app.isReady()) appReady()
+  else app.on('ready', appReady)
 
   // Set / get options
   menubar.setOption = function (opt, val) {


### PR DESCRIPTION
This is a follow-up to @CodeFusion's 977526535b709a34e6158f13bccde0bf8d2c05f5.

Electron does not allow creation of the tray object before app ready. However, if I create an app tray object in `app.on('ready' ...)`, then pass it into Menubar's constructor, still within app.ready
```
const mb = menubar({
    dir: __dirname,
    tray,
  });
```
I receive exception
```
Uncaught Exception:
TypeError: Cannot set property 'tray' of undefined
    at appReady (/Github/_project_/node_modules/menubar/index.js:53:18)
    at create (/Github/_project_/node_modules/menubar/index.js:27:22)
```
due to `app` not yet being available to Menubar. This PR addresses that issue.