### PR TITLE
Allow setting isMovable option to prevent window dragging on OSX.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = function create (opts) {
   if (!opts.index) opts.index = 'file://' + path.join(opts.dir, 'index.html')
   if (!opts.windowPosition) opts.windowPosition = (process.platform === 'win32') ? 'trayBottomCenter' : 'trayCenter'
   if (typeof opts.showDockIcon === 'undefined') opts.showDockIcon = false
+  if (typeof opts.isMovable === 'undefined') opts.isMovable = false
 
   // set width/height on opts to be usable before the window is created
   opts.width = opts.width || 400
@@ -80,7 +81,8 @@ module.exports = function create (opts) {
       menubar.emit('create-window')
       var defaults = {
         show: false,
-        frame: false
+        frame: false,
+        movable: opts.isMovable
       }
 
       var winOpts = extend(defaults, opts)

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ you can pass an optional options object into the menubar constructor
 - `windowPosition` (default trayCenter and trayBottomCenter on Windows) - Sets the window position (x and y will still override this), check [positioner docs](https://github.com/jenslind/electron-positioner#docs) for valid values.
 - `showDockIcon` (default false) - Configure the visibility of the application dock icon.
 - `showOnRightClick` (default false) - Show the window on 'right-click' event instead of regular 'click'
+- `isMovable` (default false) - Whether window is movable. This is not implemented on Linux. Default is false.
 
 ## events
 


### PR DESCRIPTION
It's currently possible to drag the window around an detach it from the tray icon. By passing the `movable` option we let users decide what should happen.