### PR TITLE
fix: Fix bug default cat icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "menubar",
   "version": "6.0.1",
-  "author": "max ogden",
+  "author": "Max Ogden",
   "bugs": {
     "url": "https://github.com/maxogden/menubar/issues"
   },
   "description": "high level way to create menubar desktop applications with electron",
   "files": [
+    "/example/*.png",
     "/lib"
   ],
   "homepage": "https://github.com/maxogden/menubar",

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,7 @@ export class Menubar extends EventEmitter {
     let trayImage =
       this.options.icon || path.join(this.options.dir, 'IconTemplate.png');
     if (typeof trayImage === 'string' && !fs.existsSync(trayImage)) {
-      trayImage = path.join(__dirname, 'example', 'IconTemplate.png'); // Default cat icon
+      trayImage = path.join(__dirname, '..', 'example', 'IconTemplate.png'); // Default cat icon
     }
 
     const defaultClickEvent = this.options.showOnRightClick


### PR DESCRIPTION
6.0.1 broke the fact that if no icon was provided, the default cat one was used. This PR fixes it.