### PR TITLE
Fix crash on Windows when the taskbar is to the left or the right

### DIFF
--- a/src/util/getWindowPosition.ts
+++ b/src/util/getWindowPosition.ts
@@ -58,10 +58,10 @@ export function getWindowPosition (tray: Tray) {
         return 'trayBottomCenter';
       }
       if (traySide === 'left') {
-        return 'bottomLeft';
+        return 'trayBottomLeft';
       }
       if (traySide === 'right') {
-        return 'bottomRight';
+        return 'trayBottomRight';
       }
   }
 }


### PR DESCRIPTION
#233 