### PR TITLE
fix: Fix crash on windows position when tray on left/right

### DIFF
--- a/src/Menubar.ts
+++ b/src/Menubar.ts
@@ -191,7 +191,9 @@ export class Menubar extends EventEmitter {
       }
     }
 
-    this._browserWindow.setPosition(x, y);
+    // `.setPosition` crashed on non-integers
+    // https://github.com/maxogden/menubar/issues/233
+    this._browserWindow.setPosition(Math.round(x), Math.round(y));
     this._browserWindow.show();
     this.emit('after-show');
     return;

--- a/src/util/getWindowPosition.ts
+++ b/src/util/getWindowPosition.ts
@@ -58,7 +58,7 @@ export function getWindowPosition (tray: Tray) {
         return 'trayBottomCenter';
       }
       if (traySide === 'left') {
-        return 'bottomLeft';
+        return 'trayBottomLeft';
       }
       if (traySide === 'right') {
         return 'bottomRight';


### PR DESCRIPTION
possibly supersedes #234 
fixes #233 

cc @pranit123 could you test this one? I tested on Windows 10, it works well