### PR TITLE
feat: Allow skipping loadUrl

### DIFF
--- a/docs/classes/_menubar_.menubar.md
+++ b/docs/classes/_menubar_.menubar.md
@@ -38,7 +38,7 @@ The main Menubar class.
 
 \+ **new Menubar**(`app`: `App`, `options?`: `Partial<Options>`): *[Menubar](_menubar_.menubar.md)*
 
-*Defined in [Menubar.ts:24](https://github.com/maxogden/menubar/blob/3e28b07/src/Menubar.ts#L24)*
+*Defined in [Menubar.ts:24](https://github.com/maxogden/menubar/blob/790f6b7/src/Menubar.ts#L24)*
 
 **Parameters:**
 
@@ -55,7 +55,7 @@ Name | Type |
 
 • **get app**(): *`App`*
 
-*Defined in [Menubar.ts:47](https://github.com/maxogden/menubar/blob/3e28b07/src/Menubar.ts#L47)*
+*Defined in [Menubar.ts:47](https://github.com/maxogden/menubar/blob/790f6b7/src/Menubar.ts#L47)*
 
 The Electron [App](https://electronjs.org/docs/api/app)
 instance.
@@ -68,7 +68,7 @@ ___
 
 • **get positioner**(): *any*
 
-*Defined in [Menubar.ts:56](https://github.com/maxogden/menubar/blob/3e28b07/src/Menubar.ts#L56)*
+*Defined in [Menubar.ts:56](https://github.com/maxogden/menubar/blob/790f6b7/src/Menubar.ts#L56)*
 
 The [electron-positioner](https://github.com/jenslind/electron-positioner)
 instance.
@@ -81,7 +81,7 @@ ___
 
 • **get tray**(): *`Tray`*
 
-*Defined in [Menubar.ts:69](https://github.com/maxogden/menubar/blob/3e28b07/src/Menubar.ts#L69)*
+*Defined in [Menubar.ts:69](https://github.com/maxogden/menubar/blob/790f6b7/src/Menubar.ts#L69)*
 
 The Electron [Tray](https://electronjs.org/docs/api/tray) instance.
 
@@ -93,7 +93,7 @@ ___
 
 • **get window**(): *`BrowserWindow` | undefined*
 
-*Defined in [Menubar.ts:83](https://github.com/maxogden/menubar/blob/3e28b07/src/Menubar.ts#L83)*
+*Defined in [Menubar.ts:83](https://github.com/maxogden/menubar/blob/790f6b7/src/Menubar.ts#L83)*
 
 The Electron [BrowserWindow](https://electronjs.org/docs/api/browser-window)
 instance, if it's present.
@@ -106,7 +106,7 @@ instance, if it's present.
 
 ▸ **getOption**<**K**>(`key`: `K`): *`Options[K]`*
 
-*Defined in [Menubar.ts:92](https://github.com/maxogden/menubar/blob/3e28b07/src/Menubar.ts#L92)*
+*Defined in [Menubar.ts:92](https://github.com/maxogden/menubar/blob/790f6b7/src/Menubar.ts#L92)*
 
 Retrieve a menubar option.
 
@@ -128,7 +128,7 @@ ___
 
 ▸ **hideWindow**(): *void*
 
-*Defined in [Menubar.ts:99](https://github.com/maxogden/menubar/blob/3e28b07/src/Menubar.ts#L99)*
+*Defined in [Menubar.ts:99](https://github.com/maxogden/menubar/blob/790f6b7/src/Menubar.ts#L99)*
 
 Hide the menubar window.
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **setOption**<**K**>(`key`: `K`, `value`: `Options[K]`): *void*
 
-*Defined in [Menubar.ts:115](https://github.com/maxogden/menubar/blob/3e28b07/src/Menubar.ts#L115)*
+*Defined in [Menubar.ts:115](https://github.com/maxogden/menubar/blob/790f6b7/src/Menubar.ts#L115)*
 
 Change an option after menubar is created.
 
@@ -163,7 +163,7 @@ ___
 
 ▸ **showWindow**(`trayPos?`: `Electron.Rectangle`): *`Promise<void>`*
 
-*Defined in [Menubar.ts:124](https://github.com/maxogden/menubar/blob/3e28b07/src/Menubar.ts#L124)*
+*Defined in [Menubar.ts:124](https://github.com/maxogden/menubar/blob/790f6b7/src/Menubar.ts#L124)*
 
 Show the menubar window.
 

--- a/docs/interfaces/_types_.options.md
+++ b/docs/interfaces/_types_.options.md
@@ -32,7 +32,7 @@ Options for creating a menubar application
 
 • **browserWindow**: *`BrowserWindowConstructorOptions`*
 
-*Defined in [types.ts:19](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L19)*
+*Defined in [types.ts:19](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L19)*
 
 An Electron BrowserWindow instance, or an options object to be passed into
 the BrowserWindow constructor.
@@ -52,7 +52,7 @@ ___
 
 • **dir**: *string*
 
-*Defined in [types.ts:23](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L23)*
+*Defined in [types.ts:23](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L23)*
 
 The app source directory.
 
@@ -62,7 +62,7 @@ ___
 
 • **icon**? : *string | `NativeImage`*
 
-*Defined in [types.ts:30](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L30)*
+*Defined in [types.ts:30](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L30)*
 
 The png icon to use for the menubar. A good size to start with is 20x20.
 To support retina, supply a 2x sized image (e.g. 40x40) with @2x added to
@@ -73,13 +73,14 @@ ___
 
 ###  index
 
-• **index**: *string*
+• **index**: *string | false*
 
-*Defined in [types.ts:38](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L38)*
+*Defined in [types.ts:39](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L39)*
 
 The URL to load the menubar's browserWindow with. The url can be a remote
 address (e.g. `http://`) or a path to a local HTML file using the
-`file://` protocol.
+`file://` protocol. If false, then menubar won't call `loadUrl` on
+start.
 
 **`default`** `file:// + options.dir + index.html`
 
@@ -91,7 +92,7 @@ ___
 
 • **preloadWindow**? : *undefined | false | true*
 
-*Defined in [types.ts:43](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L43)*
+*Defined in [types.ts:44](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L44)*
 
 Create BrowserWindow instance before it is used -- increasing resource
 usage, but making the click on the menubar load faster.
@@ -102,7 +103,7 @@ ___
 
 • **showDockIcon**? : *undefined | false | true*
 
-*Defined in [types.ts:48](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L48)*
+*Defined in [types.ts:49](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L49)*
 
 Configure the visibility of the application dock icon, macOS only. Calls
 [`app.dock.hide`](https://electronjs.org/docs/api/app#appdockhide-macos).
@@ -113,7 +114,7 @@ ___
 
 • **showOnAllWorkspaces**? : *undefined | false | true*
 
-*Defined in [types.ts:53](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L53)*
+*Defined in [types.ts:54](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L54)*
 
 Makes the window available on all OS X workspaces. Calls
 [`setVisibleOnAllWorkspaces`](https://electronjs.org/docs/api/browser-window#winsetvisibleonallworkspacesvisible-options).
@@ -124,7 +125,7 @@ ___
 
 • **showOnRightClick**? : *undefined | false | true*
 
-*Defined in [types.ts:57](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L57)*
+*Defined in [types.ts:58](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L58)*
 
 Show the window on 'right-click' event instead of regular 'click'.
 
@@ -134,7 +135,7 @@ ___
 
 • **tooltip**: *string*
 
-*Defined in [types.ts:61](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L61)*
+*Defined in [types.ts:62](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L62)*
 
 Menubar tray icon tooltip text. Calls [`tray.setTooltip`](https://electronjs.org/docs/api/tray#traysettooltiptooltip).
 
@@ -144,7 +145,7 @@ ___
 
 • **tray**? : *`Tray`*
 
-*Defined in [types.ts:65](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L65)*
+*Defined in [types.ts:66](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L66)*
 
 An electron Tray instance. If provided, `options.icon` will be ignored.
 
@@ -154,7 +155,7 @@ ___
 
 • **windowPosition**? : *"trayLeft" | "trayBottomLeft" | "trayRight" | "trayBottomRight" | "trayCenter" | "trayBottomCenter" | "topLeft" | "topRight" | "bottomLeft" | "bottomRight" | "topCenter" | "bottomCenter" | "leftCenter" | "rightCenter" | "center"*
 
-*Defined in [types.ts:70](https://github.com/maxogden/menubar/blob/3e28b07/src/types.ts#L70)*
+*Defined in [types.ts:71](https://github.com/maxogden/menubar/blob/790f6b7/src/types.ts#L71)*
 
 Sets the window position (x and y will still override this), check
 electron-positioner docs for valid values.

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -23,7 +23,7 @@ import { menubar } from 'menubar';
 
 ▸ **menubar**(`options?`: `Partial<Options>`): *[Menubar](../classes/_menubar_.menubar.md)*
 
-*Defined in [index.ts:25](https://github.com/maxogden/menubar/blob/3e28b07/src/index.ts#L25)*
+*Defined in [index.ts:25](https://github.com/maxogden/menubar/blob/790f6b7/src/index.ts#L25)*
 
 Factory function to create a menubar application
 

--- a/docs/modules/_util_getwindowposition_.md
+++ b/docs/modules/_util_getwindowposition_.md
@@ -19,7 +19,7 @@ Utilities to get taskbar position and consequently menubar's position
 
 ▸ **getWindowPosition**(`tray`: `Tray`): *`WindowPosition`*
 
-*Defined in [util/getWindowPosition.ts:52](https://github.com/maxogden/menubar/blob/3e28b07/src/util/getWindowPosition.ts#L52)*
+*Defined in [util/getWindowPosition.ts:52](https://github.com/maxogden/menubar/blob/790f6b7/src/util/getWindowPosition.ts#L52)*
 
 Depending on where the taskbar is, determine where the window should be
 positioned.
@@ -38,7 +38,7 @@ ___
 
 ▸ **taskbarLocation**(`tray`: `Tray`): *`TaskbarLocation`*
 
-*Defined in [util/getWindowPosition.ts:18](https://github.com/maxogden/menubar/blob/3e28b07/src/util/getWindowPosition.ts#L18)*
+*Defined in [util/getWindowPosition.ts:18](https://github.com/maxogden/menubar/blob/790f6b7/src/util/getWindowPosition.ts#L18)*
 
 Determine taskbard location: "top", "bottom", "left" or "right".
 

--- a/src/Menubar.ts
+++ b/src/Menubar.ts
@@ -291,7 +291,12 @@ export class Menubar extends EventEmitter {
     }
 
     this._browserWindow.on('close', this.windowClear.bind(this));
-    await this._browserWindow.loadURL(this._options.index);
+
+    // If the user explicity set options.index to false, we don't loadURL
+    // https://github.com/maxogden/menubar/issues/255
+    if (this._options.index !== false) {
+      await this._browserWindow.loadURL(this._options.index);
+    }
     this.emit('after-create-window');
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,11 +31,12 @@ export interface Options {
   /**
    * The URL to load the menubar's browserWindow with. The url can be a remote
    * address (e.g. `http://`) or a path to a local HTML file using the
-   * `file://` protocol.
+   * `file://` protocol. If false, then menubar won't call `loadUrl` on
+   * start.
    * @default `file:// + options.dir + index.html`
    * @see https://electronjs.org/docs/api/browser-window#winloadurlurl-options
    */
-  index: string;
+  index: string | false;
   /**
    * Create BrowserWindow instance before it is used -- increasing resource
    * usage, but making the click on the menubar load faster.

--- a/src/util/cleanOptions.spec.ts
+++ b/src/util/cleanOptions.spec.ts
@@ -18,7 +18,7 @@ describe('cleanOptions', () => {
     expect(cleanOptions(undefined)).toEqual(DEFAULT_OPTIONS);
   });
 
-  it('should handle a string with relative path', () => {
+  it('should handle a dir string with relative path', () => {
     expect(cleanOptions({ dir: 'MY_RELATIVE_PATH' })).toEqual({
       ...DEFAULT_OPTIONS,
       dir: path.resolve('MY_RELATIVE_PATH'),
@@ -29,7 +29,7 @@ describe('cleanOptions', () => {
     });
   });
 
-  it('should handle a string with absolute path', () => {
+  it('should handle a dir string with absolute path', () => {
     expect(cleanOptions({ dir: '/home/me/MY_ABSOLUTE_PATH' })).toEqual({
       ...DEFAULT_OPTIONS,
       dir: '/home/me/MY_ABSOLUTE_PATH',
@@ -37,7 +37,14 @@ describe('cleanOptions', () => {
     });
   });
 
-  it('should handle an object', () => {
+  it('should handle a false index', () => {
+    expect(cleanOptions({ index: false })).toEqual({
+      ...DEFAULT_OPTIONS,
+      index: false
+    });
+  });
+
+  it('should handle an object with multiple fields', () => {
     expect(
       cleanOptions({
         browserWindow: {

--- a/src/util/cleanOptions.ts
+++ b/src/util/cleanOptions.ts
@@ -28,7 +28,8 @@ export function cleanOptions(opts?: Partial<Options>): Options {
   if (!path.isAbsolute(options.dir)) {
     options.dir = path.resolve(options.dir);
   }
-  if (!options.index) {
+  // Note: options.index can be `false`
+  if (options.index === undefined) {
     options.index = url.format({
       pathname: path.join(options.dir, 'index.html'),
       protocol: 'file:',


### PR DESCRIPTION
```typescript
const mb = menubar({ index: false });
```

will not call `browserWindow.loadUrl` internally at all. It will be the user's job to call that.