### PR TITLE
fix: calling showWindow() prevents menubar window from closing

### DIFF
--- a/src/Menubar.ts
+++ b/src/Menubar.ts
@@ -199,6 +199,7 @@ export class Menubar extends EventEmitter {
     // https://github.com/maxogden/menubar/issues/233
     this._browserWindow.setPosition(Math.round(x), Math.round(y));
     this._browserWindow.show();
+    this._isVisible = true;
     this.emit('after-show');
     return;
   }
@@ -274,7 +275,6 @@ export class Menubar extends EventEmitter {
     }
 
     this._cachedBounds = bounds || this._cachedBounds;
-    this._isVisible = true;
     await this.showWindow(this._cachedBounds);
   }
 


### PR DESCRIPTION
This PR fixes the following bug: 

## Bug Description:
`this._isVisible` is only set to `true` in `clicked()` so if `showWindow()` is called directly, `this._isVisible` is not updated and prevents `closeWindow()` to work properly. 

### Step to Reproduce:
```
const { menubar } = require('menubar');

const mb = menubar();

mb.on('ready', () => {
  mb.showWindow();
});
```

The menubar window will show up but clicking outside would not close the window.