### PR TITLE
When traySide is on the left, show window at center

### DIFF
--- a/src/util/getWindowPosition.ts
+++ b/src/util/getWindowPosition.ts
@@ -73,7 +73,7 @@ export function getWindowPosition(tray: Tray): WindowPosition {
 				return 'trayBottomCenter';
 			}
 			if (traySide === 'left') {
-				return 'trayBottomLeft';
+				return 'center';
 			}
 			if (traySide === 'right') {
 				return 'bottomRight';


### PR DESCRIPTION
It's not perfect , but at least not broken.
Before this change, the window was partially hidden when taskbar is on the left