### PR TITLE
feat!:  fix `after-create-window`, add `after-window-load` event

### DIFF
--- a/src/Menubar.ts
+++ b/src/Menubar.ts
@@ -56,7 +56,7 @@ export class Menubar extends EventEmitter {
 	get positioner(): Positioner {
 		if (!this._positioner) {
 			throw new Error(
-				'Please access `this.positioner` after the `after-create-window` event has fired.'
+				'Please access `this.positioner` after the `after-window-load` event has fired.'
 			);
 		}
 
@@ -290,6 +290,8 @@ export class Menubar extends EventEmitter {
 			...defaults,
 			...this._options.browserWindow,
 		});
+		
+		this.emit('after-create-window');
 
 		this._positioner = new Positioner(this._browserWindow);
 
@@ -320,7 +322,8 @@ export class Menubar extends EventEmitter {
 				this._options.loadUrlOptions
 			);
 		}
-		this.emit('after-create-window');
+		
+		this.emit('after-window-load');
 	}
 
 	private windowClear(): void {


### PR DESCRIPTION
Previously the `after-create-window` event was fired after `loadURL` is resolved. This fixes that.

BREAKING CHANGE:
`after-create-window` now happens earlier during the window creation lifecycle.

Alternatively this could be implemented as a non breaking change: `after-create-window` would stay the same and an event name like `real-after-create-window` could be introduced instead.