### PR TITLE
fix: Avoid setVisibleOnAllWorkspaces from destroying the original visible state of app.dock

### DIFF
--- a/src/Menubar.ts
+++ b/src/Menubar.ts
@@ -307,7 +307,10 @@ export class Menubar extends EventEmitter {
 		});
 
 		if (this._options.showOnAllWorkspaces !== false) {
-			this._browserWindow.setVisibleOnAllWorkspaces(true);
+			// https://github.com/electron/electron/issues/37832#issuecomment-1497882944
+			this._browserWindow.setVisibleOnAllWorkspaces(true, {
+				skipTransformProcessType: true // Avoid damaging the original visible state of app.dock
+			});
 		}
 
 		this._browserWindow.on('close', this.windowClear.bind(this));


### PR DESCRIPTION
Due to this code change https://github.com/electron/electron/pull/37599/files , `setVisibleOnAllWorkspaces(true)` has changed its original logic, resulting in the reappearance of the already hidden dockIcon. This change avoids the occurrence of this phenomenon
The affected versions include 23.2.x 24.x.x